### PR TITLE
Add a callback option parameter

### DIFF
--- a/packages/forms/src/pages/Form.tsx
+++ b/packages/forms/src/pages/Form.tsx
@@ -12,6 +12,7 @@ import Alert from '@material-ui/lab/Alert'
 import { SurveyForm } from '../components/SurveyForm'
 
 const client = new ReportClient(config.baseUrl)
+let reportBoxSchema: ReportBoxSchema | null = null
 
 export default function FormPage() {
   const store = createStore()
@@ -24,6 +25,7 @@ export default function FormPage() {
 
   useEffect(() => {
     store.fetchSchema(id).then((schema: ReportBoxSchema) => {
+      reportBoxSchema = schema
       setSchema(schema.itemSchema)
 
       if (schema.optionalSettings.canConnectEmbeddingParent) {
@@ -38,7 +40,13 @@ export default function FormPage() {
     setLoading(true)
     try {
       await client.submit(id, e.formData)
-      setSucceeded(true)
+
+      const callbackUrl = reportBoxSchema?.optionalSettings.callbackUrl
+      if (callbackUrl) {
+        window.location.href = callbackUrl
+      } else {
+        setSucceeded(true)
+      }
     } catch(_) {
       setHasError(true)
     } finally {

--- a/packages/report-box-aws-sam/template.yml
+++ b/packages/report-box-aws-sam/template.yml
@@ -74,6 +74,7 @@ Resources:
           SCHEMA_STORE_BASE_URL: !Ref SchemaStoreBaseUrl
           SIGNED_PARAMS_SECRET: !Ref SignedParamsSecret
           DEVELOPMENT: false
+          SCHEMA_STORE_SAMPLE: false
 
 Parameters:
   FrontendOrigin:

--- a/packages/report-box-resources/src/option-settings.ts
+++ b/packages/report-box-resources/src/option-settings.ts
@@ -3,7 +3,8 @@ import { ReportBoxOptionsEmbed, ReportBoxOptionSettingsEmbed } from './embedded-
 
 export type ReportBoxOptions = {
   signedParameters?: JSONSchema7,
-  embedded?: ReportBoxOptionsEmbed
+  embedded?: ReportBoxOptionsEmbed,
+  callbackUrl?: string
 }
 
 export class ReportBoxOptionSettings {
@@ -36,6 +37,10 @@ export class ReportBoxOptionSettings {
     if (!this._embeddedOptions) throw new Error('Embedded option is not given')
 
     return this._embeddedOptions
+  }
+
+  get callbackUrl() {
+    return this._params.callbackUrl || ''
   }
 
   private _setEmbeddedOptionsIfNeeded() {

--- a/packages/report-box-resources/tests/option-settings.test.ts
+++ b/packages/report-box-resources/tests/option-settings.test.ts
@@ -79,3 +79,18 @@ describe('setParameters', () => {
     expect(option.embeddedOptions.parentOrigin).toEqual(parentOrigin)
   })
 })
+
+describe('callbackUrl', () => {
+  test('Should return callbackUrl when the option has a callbackUrl', () => {
+    const callbackUrl = 'https://example.com'
+    const option = new ReportBoxOptionSettings({callbackUrl})
+
+    expect(option.callbackUrl).toEqual(callbackUrl)
+  })
+
+  test('Should return an empty string when the callbackUrl is not given', () => {
+    const option = new ReportBoxOptionSettings({})
+
+    expect(option.callbackUrl).toEqual('')
+  })
+})

--- a/packages/schema-store-client/src/schema-store-sample.ts
+++ b/packages/schema-store-client/src/schema-store-sample.ts
@@ -6,6 +6,22 @@ export class SchemaStoreSample extends SchemaStore {
     let json = {}
 
     switch(id) {
+      case 'with-callback':
+        return new ReportBoxSchema({
+          "title": "テストフォーム",
+          "type": "object",
+          "required": ["requiredText"],
+          "properties": {
+            "requiredText": {
+              "type": "string",
+              "description": "テキストを入力してください",
+              "title": "入力必須テキスト"
+            }
+          },
+          "reportBoxOptions": {
+            "callbackUrl": "https://example.com/callback"
+          }
+        })
       default:
         return new ReportBoxSchema({
           "title": "テストフォーム",


### PR DESCRIPTION
アンケートに答えた後に任意のページに遷移できるようにします。 `reportBoxOptions.callbackUrl` が設定されていれば、設定したURLに遷移します

```json
{
  "title": "Test form",
  "type": "object",
  "required": ["requiredText"],
  "properties": {
    "requiredText": {"type": "string", "title": "text"}
  },
  "reportBoxOptions": {
    "callbackUrl": "https://example.com/callback"
  }
}
```